### PR TITLE
[BUGFIX] TCA output flexform

### DIFF
--- a/Classes/Components/ContentElementGenerator/OutputTcaAndFlexForm.php
+++ b/Classes/Components/ContentElementGenerator/OutputTcaAndFlexForm.php
@@ -130,7 +130,7 @@ class OutputTcaAndFlexForm
         $flexformString = $this->renderFlexformXml($dce);
         $sourceCode .= <<<PHP
             \$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['$dceIdentifier'] = 'pi_flexform';
-            \$GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][',$dceIdentifier'] = <<<XML
+            \$GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']['*,$dceIdentifier'] = <<<XML
             $flexformString
             XML;
 


### PR DESCRIPTION
TYPO3 CMS 10.4.23 / PHP 7.4.25
default flexform `$GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']['default']` was shown instead of those defined in DCE