### PR TITLE
Prevent undefined array key warning (PHP 8) when dce is saved without modifying flexform settings

### DIFF
--- a/Classes/Hooks/AfterSaveHook.php
+++ b/Classes/Hooks/AfterSaveHook.php
@@ -117,7 +117,7 @@ class AfterSaveHook
                         'uid' => $this->uid,
                         'CType' => $dceIdentifier,
                     ],
-                    $this->fieldArray['pi_flexform']
+                    $this->fieldArray['pi_flexform'] ?? []
                 );
                 unset($dceIdentifier);
             } else {


### PR DESCRIPTION
When a dce is saved without modifying flexform settings, an undefined array key warning appears due to the case not being handled that this field was not modified:

![image](https://user-images.githubusercontent.com/31882731/165715846-bb474dd9-8472-440f-8404-516ddfed72f8.png)
