### PR TITLE
Add optional selector for nested elements migration in FileToFile wizard

### DIFF
--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -626,8 +626,8 @@ XML;
                         }
 
                         $node = $xpath->query(
-                            "//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value
-                            |//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//section[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
+                            "//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
+                            ."|//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//section[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
                         );
                         $node->item(0)->nodeValue = implode(',', $fileUids);
                     }

--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -625,7 +625,10 @@ XML;
                             unset($mediaFileName, $newPath);
                         }
 
-                        $node = $xpath->query("//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value");
+                        $node = $xpath->query(
+                            "//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value
+                            |//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//section[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
+                        );
                         $node->item(0)->nodeValue = implode(',', $fileUids);
                     }
 


### PR DESCRIPTION
This allows to migrate nested elements using <section id="X"> as a wrapper for nested file uploads elements.

In my case FlexForm looked like this:

```
<field index="settings.slides">
                    <el index="el">
                        <section index="1">
                            <itemType index="container_slides">
                                <el>
                                    <field index="image">
                                        <value index="vDEF">_temp_14.jpg</value>
                                    </field>
```

and original xpath selector was failing, looking for `<field index="X">`

initial [report on Slack](https://typo3.slack.com/archives/C08CA1EP8/p1665856609568109)