### PR TITLE
[BUGFIX] Migrate all File to FAL in section fields

### DIFF
--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -254,26 +254,29 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                     $affectedFieldRow['_parent_section_field'] = $sectionFieldRow;
                     $dceUid = (int)$sectionFieldRow['parent_dce'];
                 }
-
-
-                $queryBuilder = DatabaseUtility::getConnectionPool()->getQueryBuilderForTable(
-                    'tx_dce_domain_model_dcefield'
-                );
-                $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
-                $dceRow = $queryBuilder
-                    ->select('*')
-                    ->from('tx_dce_domain_model_dce')
-                    ->where(
-                        $queryBuilder->expr()->eq(
-                            'uid',
-                            $queryBuilder->createNamedParameter($dceUid)
+                
+                if (!array_key_exists($dceUid, $affectedDceRows)) {
+                    $queryBuilder = DatabaseUtility::getConnectionPool()->getQueryBuilderForTable(
+                        'tx_dce_domain_model_dcefield'
+                    );
+                    $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
+                    $dceRow = $queryBuilder
+                        ->select('*')
+                        ->from('tx_dce_domain_model_dce')
+                        ->where(
+                            $queryBuilder->expr()->eq(
+                                'uid',
+                                $queryBuilder->createNamedParameter($dceUid)
+                            )
                         )
-                    )
-                    ->execute()
-                    ->fetch();
-
-                $affectedDceRows[$dceUid] = $dceRow;
-                $affectedDceRows[$dceUid]['_affectedFields'] = [$affectedFieldRow];
+                        ->execute()
+                        ->fetch();
+                        
+                    $affectedDceRows[$dceUid] = $dceRow;
+                    $affectedDceRows[$dceUid]['_affectedFields'] = [$affectedFieldRow];
+                } else {
+                    $affectedDceRows[$dceUid]['_affectedFields'][] = $affectedFieldRow;
+                }
             } else {
                 $affectedDceRows[$dceUid]['_affectedFields'][] = $affectedFieldRow;
             }


### PR DESCRIPTION
Versions

- DCE version: 2.9.3
- TYPO3 version: 10.4.32
- PHP version: 7.4

If there is more than one file upload field in a section field, only the latest media file is migrated to FAL. This patch migrate all media files in the section.

I didn't do a thorough test in conjunction with file upload fields outside of a section, so test the code again before merging.