### PR TITLE
[BUGFIX] Don’t use absolute File Paths

### DIFF
--- a/Classes/UserFunction/FormEngineNode/DceCodeMirrorFieldRenderType.php
+++ b/Classes/UserFunction/FormEngineNode/DceCodeMirrorFieldRenderType.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * Codemirror text area field.
@@ -43,9 +44,9 @@ class DceCodeMirrorFieldRenderType extends AbstractFormElement
         $mode = $this->data['parameterArray']['fieldConf']['config']['parameters']['mode'];
         $this->resultArray = $this->initializeResultArray();
         $this->resultArray['stylesheetFiles'][] =
-            'EXT:dce/Resources/Public/JavaScript/Contrib/codemirror/lib/codemirror.css';
+            PathUtility::getAbsoluteWebPath(GeneralUtility::getFileAbsFileName('EXT:dce/Resources/Public/JavaScript/Contrib/codemirror/lib/codemirror.css'));
         $this->resultArray['stylesheetFiles'][] =
-            'EXT:dce/Resources/Public/Css/custom_codemirror.css';
+            PathUtility::getAbsoluteWebPath(GeneralUtility::getFileAbsFileName('EXT:dce/Resources/Public/Css/custom_codemirror.css'));
         $this->resultArray['requireJsModules'][] = [
             'TYPO3/CMS/Dce/DceCodemirror' => 'function(DceCodemirror, $) { DceCodemirror.initCodeMirrorEditor("#codemirror_' .
                 $this->uniqueIdentifier . '", "' . $mode . '"); }',


### PR DESCRIPTION
If you use Composer Install in new Mode
https://github.com/TYPO3/CmsComposerInstallers/releases/tag/v4.0.0-RC1

Don’t use absolute File Paths for CSS and JS

See Issue https://github.com/a-r-m-i-n/dce/issues/53