### PR TITLE
[TASK] Fix warnings in backend

### DIFF
--- a/Classes/Domain/Model/Dce.php
+++ b/Classes/Domain/Model/Dce.php
@@ -841,7 +841,7 @@ class Dce extends AbstractEntity
         if (!empty($section)) {
             $backendTemplateParts = GeneralUtility::trimExplode($backendTemplateSeparator, $fullBackendTemplate);
 
-            return 'bodytext' === $section ? $backendTemplateParts[1] : $backendTemplateParts[0];
+            return 'bodytext' === $section ? ($backendTemplateParts[1] ?? null) : ($backendTemplateParts[0] ?? null);
         }
 
         return $fullBackendTemplate;


### PR DESCRIPTION
doing an upgrade of a project I get a lot of warnings on some pages
```
Core: Error handler (BE): PHP Warning: Undefined array key 1 in /var/www/html/public/typo3conf/ext/dce/Classes/Domain/Model/Dce.php line 844
```

tbh I don't know if this is an issue of a wrong integration, anyway, I propose this check to avoid notices with PHP8