### PR TITLE
[BUGFIX] Fix TtContentLabel userfunction in case of incomplete data

### DIFF
--- a/Classes/UserFunction/CustomLabels/TtContentLabel.php
+++ b/Classes/UserFunction/CustomLabels/TtContentLabel.php
@@ -30,7 +30,7 @@ class TtContentLabel
      */
     public function getLabel(array &$parameter): void
     {
-        if (!isset($parameter['row'])) {
+        if (!isset($parameter['row']) || !isset($parameter['row']['CType'])) {
             return;
         }
         if ((\is_string($parameter['row']['CType']) || is_array($parameter['row']['CType'])) &&


### PR DESCRIPTION
In some cases, incomplete data may be passed to
TtContentLabel::getLabel(). Due to this we perform a check for missing field 'CType' first.

This fixes a problem if editing of the pi_flexform field of dce content elements is invoked by using the Fluid ViewHelper link.editRecord with parameter "fields", for example, e.g.

<be:link.editRecord uid="{uid}" table="tt_content"
  fields="pi_flexform">edit record {uid} pi_flexform
</be:link.editRecord>

Resolves: #102