### PR TITLE
Bugfix Backend Problem with Powermail Forms

### DIFF
--- a/Classes/EventListener/AfterFormEnginePageInitializedEventListener.php
+++ b/Classes/EventListener/AfterFormEnginePageInitializedEventListener.php
@@ -19,7 +19,7 @@ class AfterFormEnginePageInitializedEventListener
     {
         $editParams = $event->getRequest()->getQueryParams()['edit'] ?? null;
 
-        if (array_key_exists('tx_dce_domain_model_dce', $editParams)) {
+        if (is_array($editParams) && array_key_exists('tx_dce_domain_model_dce', $editParams)) {
             $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
                 JavaScriptModuleInstruction::create('@t3/dce/code-editor')
             );


### PR DESCRIPTION
The missing array check results in an exception in the backend 

Core: Exception handler (WEB): Uncaught TYPO3 Exception: array_key_exists(): Argument #2 ($array) must be of type array, null given | TypeError thrown in file /home/live/web/example.com/public_html/typo3conf/ext/dce/Classes/EventListener/AfterFormEnginePageInitializedEventListener.php in line 22. Requested URL: https://www.example.com/typo3/record/edit?token=--AnonymizedToken--&id=1410