### PR TITLE
Update ModifyDatabaseQueryForRecordListingEventListener.php

### DIFF
--- a/Classes/EventListener/ModifyDatabaseQueryForRecordListingEventListener.php
+++ b/Classes/EventListener/ModifyDatabaseQueryForRecordListingEventListener.php
@@ -20,7 +20,8 @@ class ModifyDatabaseQueryForRecordListingEventListener
                 $event->getQueryBuilder()->expr()->like(
                     'tx_dce_index',
                     $event->getQueryBuilder()->quote('%' . $event->getQueryBuilder()->escapeLikeWildcards($event->getDatabaseRecordList()->searchString) . '%')
-                )
+                ),
+                $event->getQueryBuilder()->expr()->in('pid', $queryBuilder->getParameters()['dcValue1'])
             );
             $queryBuilder->orWhere($expression);
             $event->setQueryBuilder($queryBuilder);


### PR DESCRIPTION
fix: include current page restrictions in `extendSearchStringConstraints`

In list view only DCE elements on the currently selected page, or the page ids of the searchconditions should be included in the results.

#134 