### PR TITLE
[BUGFIX] Fix "FileToFalUpdate" wizard

### DIFF
--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -544,24 +544,24 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                             $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
                         } catch (\InvalidArgumentException $e) {
                         }
-                        if (!isset($file)) {
-                            throw new \RuntimeException('Unable to get file from fileadmin storage with identifier "' . $newPath . '"');
+                        if (isset($file)) {
+                            $newSysFileReference = [
+                                'table_local' => 'sys_file',
+                                'uid_local' => $file->getUid(),
+                                'tablenames' => 'tt_content',
+                                'fieldname' => $affectedFieldRow['variable'],
+                                'uid_foreign' => $elementRow['uid'],
+                                'sys_language_uid' => $elementRow['sys_language_uid'],
+                                'sorting_foreign' => $i,
+                                'pid' => $elementRow['pid'],
+                            ];
+
+                            $sysFileReferenceConnection->insert('sys_file_reference', $newSysFileReference);
+                            $newSysFileReferenceUid = $sysFileReferenceConnection->lastInsertId('sys_file_reference');
+                            $this->logger->info('Added new sys_file_reference with uid ' . $newSysFileReferenceUid, ['values' => $newSysFileReference]);
+                        } else {
+                            $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
                         }
-
-                        $newSysFileReference = [
-                            'table_local' => 'sys_file',
-                            'uid_local' => $file->getUid(),
-                            'tablenames' => 'tt_content',
-                            'fieldname' => $affectedFieldRow['variable'],
-                            'uid_foreign' => $elementRow['uid'],
-                            'sys_language_uid' => $elementRow['sys_language_uid'],
-                            'sorting_foreign' => $i,
-                            'pid' => $elementRow['pid'],
-                        ];
-
-                        $sysFileReferenceConnection->insert('sys_file_reference', $newSysFileReference);
-                        $newSysFileReferenceUid = $sysFileReferenceConnection->lastInsertId('sys_file_reference');
-                        $this->logger->info('Added new sys_file_reference with uid ' . $newSysFileReferenceUid, ['values' => $newSysFileReference]);
                     }
 
                     // Replace image name(s) with amount of relations, in pi_flexform of DCE content element
@@ -578,6 +578,8 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                     $ttContentConnection->update('tt_content', [
                         'pi_flexform' => $updatedFlexform,
                     ], ['uid' => $elementRow['uid']]);
+
+                    $this->logger->info('Updated content element (uid=' . $elementRow['uid'] . ') flexform values.');
                 }
             }
         }
@@ -628,10 +630,11 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                                     $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
                                 } catch (\InvalidArgumentException $e) {
                                 }
-                                if (!isset($file)) {
-                                    throw new \RuntimeException('Unable to get file from fileadmin storage with identifier "' . $newPath . '"');
+                                if (isset($file)) {
+                                    $fileUids[] = $file->getUid();
+                                } else {
+                                    $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
                                 }
-                                $fileUids[] = $file->getUid();
                                 unset($mediaFileName, $newPath);
                             }
 
@@ -649,7 +652,7 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                         'pi_flexform' => $updatedFlexform,
                     ], ['uid' => $elementRow['uid']]);
 
-                    $this->logger->info('Updated content element (uid=' . $elementRow['uid'] . ' flexform values.');
+                    $this->logger->info('Updated content element (uid=' . $elementRow['uid'] . ') flexform values.');
                 }
             }
         }

--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -51,6 +51,11 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
      */
     private $fileStorageRepository;
 
+    /**
+     * @var string
+     */
+    private $fileadminBasePath;
+
     public function __construct(DceRepository $dceRepository, StorageRepository $fileStorageRepository)
     {
         $this->dceRepository = $dceRepository;
@@ -134,12 +139,13 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                             $images = GeneralUtility::trimExplode(',', $images, true);
 
                             foreach ($images as $imageFileName) {
-                                $path = Environment::getPublicPath() . DIRECTORY_SEPARATOR . $uploadFolder . DIRECTORY_SEPARATOR . $imageFileName;
+                                $path = $this->getPublicAbsPath($uploadFolder, $imageFileName);
+                                $relPath = $this->getPublicRelPath($uploadFolder, $imageFileName);
                                 if (file_exists($path)) {
                                     $imagesFound[] = $path;
                                 } else {
                                     $imagesMissing[] = $path;
-                                    $imagesMissingText .= '- ' . substr($path, strlen(Environment::getPublicPath())) . PHP_EOL;
+                                    $imagesMissingText .= '- ' . $relPath . PHP_EOL;
                                 }
                             }
                         }
@@ -289,7 +295,6 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
     private function createNewFoldersInFileadmin(?array $affectedFieldRows): void
     {
         $this->logger->debug('Checking for new folders to create in fileadmin');
-        $fileadminBasePath = $this->getFileadminBasePath();
 
         $createdFolderPaths = [];
         $error = false;
@@ -299,8 +304,12 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
             $flexformConfig = FlexformService::xmlToArray($conf);
             $flexformConfig = $flexformConfig['root']['config'] ?? [];
 
-            $uploadFolder = $flexformConfig['uploadfolder'] ?? null;
-            $newFolderPath = $fileadminBasePath . DIRECTORY_SEPARATOR . $uploadFolder;
+            if (empty($flexformConfig['uploadfolder'])) {
+                continue;
+            }
+
+            $uploadFolder = $flexformConfig['uploadfolder'];
+            $newFolderPath = $this->getFileadminAbsPath($uploadFolder);
 
             if (!in_array($newFolderPath, $createdFolderPaths, true)) {
                 if (!file_exists($newFolderPath)) {
@@ -322,7 +331,6 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
 
     private function moveAndIndexMediaFiles(array $affectedDceRows)
     {
-        $fileadminBasePath = $this->getFileadminBasePath();
         $movedFiles = [];
         $this->logger->debug('Moving old media files');
 
@@ -362,19 +370,20 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                     $media = GeneralUtility::trimExplode(',', $media, true);
 
                     foreach ($media as $mediaFileName) {
-                        $oldPath = Environment::getPublicPath() . DIRECTORY_SEPARATOR . $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
+                        $oldPath = $this->getPublicAbsPath($uploadFolder, $mediaFileName);
                         if (in_array($oldPath, $movedFiles, true)) {
                             $this->logger->debug('Image "' . $oldPath . '" already moved. Skipping.');
                             continue;
                         }
                         if (file_exists($oldPath)) {
-                            $newPath = $fileadminBasePath . DIRECTORY_SEPARATOR . $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
+                            $newPath = $this->getFileadminAbsPath($uploadFolder, $mediaFileName);
+                            $newRelPath = $this->getFileadminRelPath($uploadFolder, $mediaFileName);
                             $status = rename($oldPath, $newPath);
                             if (!$status) {
                                 throw new \RuntimeException(sprintf('Unable to move media file from "%s" to "%s".', $oldPath, $newPath));
                             }
                             $this->logger->info('Moved media file successfully', ['from' => $oldPath, 'to' => $newPath]);
-                            $movedFiles[$newPath] = $oldPath;
+                            $movedFiles[$newRelPath] = $oldPath;
                         } else {
                             $this->logger->error('Old image path "' . $oldPath . '" not found!', ['tt_content_uid' => $elementRow['uid'], 'dce' => $dce->getTitle(), 'field' => $affectedFieldRow['variable']]);
                         }
@@ -390,9 +399,8 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
         $currentEvaluatePermissionsValue = $storage->getEvaluatePermissions();
         $storage->setEvaluatePermissions(false);
         $indexer = GeneralUtility::makeInstance(Indexer::class, $storage);
-        foreach (array_keys($movedFiles) as $newPath) {
-            $movedFileIdentifier = substr($newPath, strlen($fileadminBasePath) + 1);
-            $indexer->createIndexEntry($movedFileIdentifier);
+        foreach (array_keys($movedFiles) as $newRelPath) {
+            $indexer->createIndexEntry($newRelPath);
         }
         $storage->setEvaluatePermissions($currentEvaluatePermissionsValue);
         $this->logger->debug('Indexing of new files in FAL successfully completed');
@@ -539,9 +547,9 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
 
                     // Create new sys_file_reference for every media file found
                     foreach ($media as $i => $mediaFileName) {
-                        $newPath = $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
+                        $newRelPath = $this->getFileadminRelPath($uploadFolder, $mediaFileName);
                         try {
-                            $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
+                            $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newRelPath);
                         } catch (\InvalidArgumentException $e) {
                         }
                         if (isset($file)) {
@@ -560,7 +568,7 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                             $newSysFileReferenceUid = $sysFileReferenceConnection->lastInsertId('sys_file_reference');
                             $this->logger->info('Added new sys_file_reference with uid ' . $newSysFileReferenceUid, ['values' => $newSysFileReference]);
                         } else {
-                            $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
+                            $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newRelPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
                         }
                     }
 
@@ -625,17 +633,17 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                             // Get sys_file uid and replace filename with uid in section field flexform
                             $fileUids = [];
                             foreach ($media as $i => $mediaFileName) {
-                                $newPath = $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
+                                $newRelPath = $this->getFileadminRelPath($uploadFolder, $mediaFileName);
                                 try {
-                                    $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
+                                    $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newRelPath);
                                 } catch (\InvalidArgumentException $e) {
                                 }
                                 if (isset($file)) {
                                     $fileUids[] = $file->getUid();
                                 } else {
-                                    $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
+                                    $this->logger->error('Unable to get file from fileadmin storage with identifier "' . $newRelPath . '". Removing from flexform of content element (uid=' . $elementRow['uid'] . ').');
                                 }
-                                unset($mediaFileName, $newPath);
+                                unset($mediaFileName, $newRelPath);
                             }
 
                             $node = $xpath->query(
@@ -658,12 +666,50 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
         }
     }
 
+    private function getPublicAbsPath(...$folders): string
+    {
+        return Environment::getPublicPath() . DIRECTORY_SEPARATOR . $this->getPublicRelPath(...$folders);
+    }
+
+    private function getPublicRelPath(...$folders): string
+    {
+        return $this->getPath(...$folders);
+    }
+
+    private function getPath(...$folders): string
+    {
+        $folders = array_filter($folders, function ($folder) {
+            return !empty($folder);
+        });
+
+        $folders = array_map(function ($folder) {
+            return trim($folder, DIRECTORY_SEPARATOR);
+        }, $folders);
+
+        return implode(DIRECTORY_SEPARATOR, $folders);
+    }
+
+    private function getFileadminAbsPath(...$folders): string
+    {
+        return Environment::getPublicPath() . DIRECTORY_SEPARATOR . $this->getFileadminBasePath() . DIRECTORY_SEPARATOR . $this->getFileadminRelPath(...$folders);
+    }
+
     private function getFileadminBasePath(): string
     {
-        /** @var ResourceStorage $fileStorage */
-        $fileStorage = $this->fileStorageRepository->findByUid(self::FILEADMIN_STORAGE_UID);
-        $fileStorageConfiguration = $fileStorage->getStorageRecord()['configuration'];
+        if ($this->fileadminBasePath === null) {
+            /** @var ResourceStorage $resourceStorage */
+            $resourceStorage = $this->fileStorageRepository->findByUid(self::FILEADMIN_STORAGE_UID);
+            $this->fileadminBasePath = trim($resourceStorage->getConfiguration()['basePath'], DIRECTORY_SEPARATOR);
+        }
 
-        return Environment::getPublicPath() . DIRECTORY_SEPARATOR . $fileStorageConfiguration['basePath'];
+        return $this->fileadminBasePath;
+    }
+
+    private function getFileadminRelPath(...$folders): string
+    {
+        $basePath = $this->getFileadminBasePath();
+        $relPath = $this->getPath(...$folders);
+
+        return strpos($relPath, $basePath) === 0 ? substr($relPath, strlen($basePath) + 1) : $relPath;
     }
 }

--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -121,10 +121,12 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                             if (0 === $affectedFieldRow['parent_dce']) {
                                 // Resolve section field contents
                                 $images = '';
-                                foreach ($flexformData[$affectedFieldRow['_parent_section_field']['variable']] ?? [] as $key => $child) {
-                                    $child = reset($child);
-                                    $images .= $child[$affectedFieldRow['variable']];
-                                    $images .= ',';
+                                if (is_array($flexformData[$affectedFieldRow['_parent_section_field']['variable']] ?? '')) {
+                                    foreach ($flexformData[$affectedFieldRow['_parent_section_field']['variable']] as $key => $child) {
+                                        $child = reset($child);
+                                        $images .= $child[$affectedFieldRow['variable']];
+                                        $images .= ',';
+                                    }
                                 }
                             } else {
                                 $images = $flexformData[$affectedFieldRow['variable']] ?? '';
@@ -349,10 +351,12 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                     if (0 === $affectedFieldRow['parent_dce']) {
                         // Resolve section field contents
                         $media = '';
-                        foreach ($flexformData[$affectedFieldRow['_parent_section_field']['variable']] as $key => $child) {
-                            $child = reset($child);
-                            $media .= $child[$affectedFieldRow['variable']];
-                            $media .= ',';
+                        if (is_array($flexformData[$affectedFieldRow['_parent_section_field']['variable']] ?? '')) {
+                            foreach ($flexformData[$affectedFieldRow['_parent_section_field']['variable']] as $key => $child) {
+                                $child = reset($child);
+                                $media .= $child[$affectedFieldRow['variable']];
+                                $media .= ',';
+                            }
                         }
                     } else {
                         $media = $flexformData[$affectedFieldRow['variable']] ?? '';
@@ -612,31 +616,33 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
                     $uploadFolder = $flexformConfig['uploadfolder'] ?? null;
 
                     // Resolve section field contents
-                    foreach ($flexformSettings[$affectedFieldRow['_parent_section_field']['variable']] as $sectionIndexKey => $child) {
-                        $child = reset($child);
-                        $media = $child[$affectedFieldRow['variable']];
-                        $media = GeneralUtility::trimExplode(',', $media, true);
+                    if (is_array($flexformSettings[$affectedFieldRow['_parent_section_field']['variable']] ?? '')) {
+                        foreach ($flexformSettings[$affectedFieldRow['_parent_section_field']['variable']] as $sectionIndexKey => $child) {
+                            $child = reset($child);
+                            $media = $child[$affectedFieldRow['variable']];
+                            $media = GeneralUtility::trimExplode(',', $media, true);
 
-                        // Get sys_file uid and replace filename with uid in section field flexform
-                        $fileUids = [];
-                        foreach ($media as $i => $mediaFileName) {
-                            $newPath = $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
-                            try {
-                                $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
-                            } catch (\InvalidArgumentException $e) {
+                            // Get sys_file uid and replace filename with uid in section field flexform
+                            $fileUids = [];
+                            foreach ($media as $i => $mediaFileName) {
+                                $newPath = $uploadFolder . DIRECTORY_SEPARATOR . $mediaFileName;
+                                try {
+                                    $file = $resourceFactory->getFileObjectByStorageAndIdentifier(self::FILEADMIN_STORAGE_UID, $newPath);
+                                } catch (\InvalidArgumentException $e) {
+                                }
+                                if (!isset($file)) {
+                                    throw new \RuntimeException('Unable to get file from fileadmin storage with identifier "' . $newPath . '"');
+                                }
+                                $fileUids[] = $file->getUid();
+                                unset($mediaFileName, $newPath);
                             }
-                            if (!isset($file)) {
-                                throw new \RuntimeException('Unable to get file from fileadmin storage with identifier "' . $newPath . '"');
-                            }
-                            $fileUids[] = $file->getUid();
-                            unset($mediaFileName, $newPath);
+
+                            $node = $xpath->query(
+                                "//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
+                                . "|//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//section[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
+                            );
+                            $node->item(0)->nodeValue = implode(',', $fileUids);
                         }
-
-                        $node = $xpath->query(
-                            "//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//field[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
-                            . "|//field[@index='settings." . $affectedFieldRow['_parent_section_field']['variable'] . "']//section[@index='" . $sectionIndexKey . "']//field[@index='" . $affectedFieldRow['variable'] . "']/value"
-                        );
-                        $node->item(0)->nodeValue = implode(',', $fileUids);
                     }
 
                     $updatedFlexform = $elementFlexformContents->saveXML();

--- a/Classes/UpdateWizards/FileToFalUpdateWizard.php
+++ b/Classes/UpdateWizards/FileToFalUpdateWizard.php
@@ -236,34 +236,32 @@ class FileToFalUpdateWizard implements UpgradeWizardInterface, LoggerAwareInterf
     {
         $affectedDceRows = [];
         foreach ($affectedFieldRows as $affectedFieldRow) {
-            $dceUid = 0;
-            if (!array_key_exists($affectedFieldRow['parent_dce'], $affectedDceRows)) {
-                $dceUid = (int)$affectedFieldRow['parent_dce'];
+            $dceUid = (int)$affectedFieldRow['parent_dce'];
 
-                // Handle section fields
-                $sectionFieldRow = null;
-                if (0 === $dceUid) {
-                    $queryBuilder = DatabaseUtility::getConnectionPool()->getQueryBuilderForTable(
-                        'tx_dce_domain_model_dcefield'
-                    );
-                    $sectionFieldRow = $queryBuilder
-                        ->select('*')
-                        ->from('tx_dce_domain_model_dcefield')
-                        ->where(
-                            $queryBuilder->expr()->eq(
-                                'uid',
-                                $queryBuilder->createNamedParameter($affectedFieldRow['parent_field'])
-                            )
-                        )
-                        ->executeQuery()
-                        ->fetchAssociative();
-
-                    $affectedFieldRow['_parent_section_field'] = $sectionFieldRow;
-                    $dceUid = (int)$sectionFieldRow['parent_dce'];
-                }
-
+            // Handle section fields
+            if (0 === $dceUid) {
                 $queryBuilder = DatabaseUtility::getConnectionPool()->getQueryBuilderForTable(
                     'tx_dce_domain_model_dcefield'
+                );
+                $sectionFieldRow = $queryBuilder
+                    ->select('*')
+                    ->from('tx_dce_domain_model_dcefield')
+                    ->where(
+                        $queryBuilder->expr()->eq(
+                            'uid',
+                            $queryBuilder->createNamedParameter($affectedFieldRow['parent_field'])
+                        )
+                    )
+                    ->executeQuery()
+                    ->fetchAssociative();
+
+                $affectedFieldRow['_parent_section_field'] = $sectionFieldRow;
+                $dceUid = (int)$sectionFieldRow['parent_dce'];
+            }
+
+            if (!array_key_exists($dceUid, $affectedDceRows)) {
+                $queryBuilder = DatabaseUtility::getConnectionPool()->getQueryBuilderForTable(
+                    'tx_dce_domain_model_dce'
                 );
                 $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
                 $dceRow = $queryBuilder


### PR DESCRIPTION
Hello Armin,

this PR is a collection of fixes that were required to make the "FileToFalUpdate" wizard run via

```
vendor/bin/typo3 upgrade:run dceFileToFalUpdate
```

successfully during my upgrade from TYPO3 v8 with DCE v1.6 to TYPO3 v9 with DCE v2.9 on PHP 7.3.

I tested every line by production runs and step debugging. The fixes are not complex and should be intuitive. At best, they would be backported to 2.x, when most users would run this wizard.

Greetings and thanks for your efforts, Alex