### PR TITLE
[BUGFIX] Force type to XML

### DIFF
--- a/Classes/Utility/DatabaseUtility.php
+++ b/Classes/Utility/DatabaseUtility.php
@@ -132,7 +132,7 @@ class DatabaseUtility
         $dceRepository = GeneralUtility::makeInstance(DceRepository::class);
 
         // Convert flexform XML to array
-        $flexData = FlexformService::get()->convertFlexFormContentToArray($contentElement['pi_flexform'] ?? '');
+        $flexData = FlexformService::get()->convertFlexFormContentToArray((string)$contentElement['pi_flexform'] ?? '');
 
         // Retrieve DCE domain model object
         $dceUid = self::getDceUidByContentElementRow($contentElement);


### PR DESCRIPTION
FlexFormService::convertFlexFormContentToArray calls GeneralUtility::xml2array which requires to have the xml as string.

In my upgrade project, this was null. 

A type cast solves it